### PR TITLE
Add Hydra sweep support

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,20 @@
+defaults:
+  - _self_
+
+num_epochs: 10
+num_train_sample: 1
+validation: true
+kl_type: mean
+entropy_type: conditional
+dataset: cifar10
+gamma: 1.0
+lambda_info: 1.0
+run_id: "gamma_${gamma}_lambda_${lambda_info}"
+base_dir: ./hydra_experiments
+
+hydra:
+  run:
+    dir: ${base_dir}/${run_id}
+  sweep:
+    dir: ${base_dir}
+    subdir: ${run_id}

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - torchvision --index-url https://download.pytorch.org/whl/cu126
     - rich
     - prettytable
+    - hydra-core

--- a/hydra_sweep.py
+++ b/hydra_sweep.py
@@ -1,0 +1,56 @@
+import torch
+from torch.optim.lr_scheduler import LambdaLR
+import hydra
+from omegaconf import DictConfig
+
+from model import StoResNet18
+from main import schedule
+
+# reuse main function but with configurable lambda_info and gamma
+from main import main as run_main
+
+@hydra.main(config_path="configs", config_name="config")
+def run(cfg: DictConfig) -> None:
+    sgd_params = {'momentum': 0.9, 'dampening': 0.0, 'nesterov': True}
+    det_params = {'lr': 0.1, 'weight_decay': 5e-4}
+    sto_params = {'lr': 0.1, 'weight_decay': 0.0, 'momentum': 0.0, 'nesterov': False}
+
+    det_milestones = (0.5, 0.9)
+    sto_milestones = (0.5, 0.9)
+    lr_ratio_det = 0.01
+    lr_ratio_sto = 1/3
+
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = StoResNet18(10, 2, 1., 0.5, (1.0, 0.5), (0.05, 0.02), 0.1, mode='in')
+    model = model.to(device)
+    optimizer = torch.optim.SGD([
+        {'params': [p for n, p in model.named_parameters() if 'posterior' not in n and 'prior' not in n], **det_params},
+        {'params': [p for n, p in model.named_parameters() if 'posterior' in n or 'prior' in n], **sto_params}
+    ], **sgd_params)
+    scheduler = LambdaLR(optimizer, [
+        lambda e: schedule(cfg.num_epochs, e, det_milestones, lr_ratio_det),
+        lambda e: schedule(cfg.num_epochs, e, sto_milestones, lr_ratio_sto)
+    ])
+
+    run_main(
+        num_train_sample=cfg.num_train_sample,
+        device=device,
+        validation=cfg.validation,
+        num_epochs=cfg.num_epochs,
+        logging_freq=1,
+        kl_type=cfg.kl_type,
+        gamma=cfg.gamma,
+        lambda_info=cfg.lambda_info,
+        entropy_type=cfg.entropy_type,
+        det_checkpoint=None,
+        dataset=cfg.dataset,
+        save_freq=1,
+        base_dir=cfg.base_dir,
+        run_id=cfg.run_id,
+        model=model,
+        scheduler=scheduler,
+        optimizer=optimizer,
+    )
+
+if __name__ == "__main__":
+    run()

--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ def get_corruptdataloader(intensity=1, test_batch_size=8, num_test_sample=1,
 
 
 def main(num_train_sample, device, validation, num_epochs, logging_freq,
-         kl_type, gamma, entropy_type, det_checkpoint, dataset, save_freq,
+         kl_type, gamma, lambda_info, entropy_type, det_checkpoint, dataset, save_freq,
          base_dir, run_id, model, scheduler, optimizer):
 
     kl_min = 0.0
@@ -138,8 +138,9 @@ def main(num_train_sample, device, validation, num_epochs, logging_freq,
     for epoch in range(num_epochs):
         # Entraîne pour une époque
         eloglike, kl, entropy = train_epoch(
-            model, train_loader, optimizer, scheduler, device, epoch, 
-            num_train_sample, kl_type, gamma, entropy_type, n_batch
+            model, train_loader, optimizer, scheduler, device, epoch,
+            num_train_sample, kl_type, gamma, entropy_type, n_batch,
+            lambda_info=lambda_info
         )
 
         # Stocke les métriques d'entraînement
@@ -271,6 +272,7 @@ if __name__ == "__main__":
         logging_freq=1,
         kl_type="mean",  # mean, full, upper_bound
         gamma=1.0,
+        lambda_info=1.0,
         entropy_type="conditional",
         det_checkpoint=None,
         dataset="cifar10",

--- a/train.py
+++ b/train.py
@@ -11,7 +11,8 @@ def get_vi_weight(epoch, kl_min, kl_max, last_iter):
 
 
 def train_epoch(model, train_loader, optimizer, scheduler, device, epoch,
-                num_train_sample, kl_type, gamma, entropy_type, n_batch):
+                num_train_sample, kl_type, gamma, entropy_type, n_batch,
+                lambda_info=1.0):
     model.train()
     total_eloglike = 0.0
     last_kl = 0.0
@@ -19,7 +20,6 @@ def train_epoch(model, train_loader, optimizer, scheduler, device, epoch,
     kl_min = 0.0
     kl_max = 1.0
     last_iter = 200
-    lambda_ = 1.0
 
     for inputs, targets in tqdm(train_loader):
         inputs = inputs.to(device, non_blocking=True)
@@ -32,7 +32,7 @@ def train_epoch(model, train_loader, optimizer, scheduler, device, epoch,
         )
         vi_weight = get_vi_weight(epoch, kl_min, kl_max, last_iter)
         mutual_info = model.mutual_information(inputs, logits, alpha, num_train_sample, entropy_type)
-        loss = eloglike - vi_weight * (kl - gamma * entropy + lambda_ * mutual_info) / (n_batch * inputs.size(0))
+        loss = eloglike - vi_weight * (kl - gamma * entropy + lambda_info * mutual_info) / (n_batch * inputs.size(0))
         elbo_loss = eloglike - vi_weight * (kl ) / (n_batch * inputs.size(0))
 
         loss.backward()
@@ -48,7 +48,7 @@ def train_epoch(model, train_loader, optimizer, scheduler, device, epoch,
             )
             vi_weight = get_vi_weight(epoch, kl_min, kl_max, last_iter)
             mutual_info = model.mutual_information(inputs, logits, alpha, num_train_sample, entropy_type)
-            loss = eloglike - vi_weight * (kl - gamma * entropy + lambda_ * mutual_info) / (n_batch * inputs.size(0))
+            loss = eloglike - vi_weight * (kl - gamma * entropy + lambda_info * mutual_info) / (n_batch * inputs.size(0))
             elbo_loss = eloglike - vi_weight * (kl ) / (n_batch * inputs.size(0))
 
         # Calculate the difference in loss


### PR DESCRIPTION
## Summary
- parameterize mutual information weight in training loop
- update call sites in `main.py`
- add Hydra-based sweep script and default config
- update environment dependencies to include Hydra

## Testing
- `python -m py_compile $(git ls-files '*.py')`

## Example usage:

```bash
python hydra_sweep.py -m \
  gamma=0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0 \
  lambda_info=0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0
```